### PR TITLE
Update README typos and syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Objectives
 
-1. Understand the asynchronous nature of Javascript.
+1. Understand the asynchronous nature of JavaScript.
 2. Use a `Promise` to create an asynchronous handler.
 3. Use `await` and `async` to handle asynchronous code.
 
@@ -12,9 +12,9 @@
 
 I highly recommend watching that video and then going through the README and trying to follow the examples. This is a hard one, it's okay if you don't fully get the implementation, but just understand the problem and that it is solved through Promises.
 
-## Asynchronous Javascript
+## Asynchronous JavaScript
 
-Javascript is an asynchronous language which means that code does not execute linearly and if one line of code has logic that might not resolve immediately, rather than wait for that resolution, the interpreter will continue to evaluate the rest of the code.
+JavaScript is an asynchronous language which means that code does not execute linearly. If one line of code has logic that might not resolve immediately, rather than wait for that resolution, the interpreter will continue to evaluate the rest of the code.
 
 **File: [synchronousExample.js](https://github.com/learn-co-curriculum/node-promises-async-await-readme/blob/master/synchronousExample.js)**
 ```js
@@ -45,9 +45,9 @@ In the script above, we have our main program wrapped in a function `main` which
 
 As you can see, the script executes entirely linearly. Since the data in `getData` is instantly available, javascript doesn't have to wait for anything and everything just works.
 
-*Note: `JSON.stringify(data)` just makes it so that the data object log nicely as: `[{"name":"Avi"},{"name":"Grace"}]`*
+*Note: `JSON.stringify(data)` just makes it so that the our data object logs nicely as: `[{"name":"Avi"},{"name":"Grace"}]`*
 
-However often in javascript, data is coming from a source not instantly available, either an HTTP request via AJAX or a Database request. We're going to simulate having to wait for data using the [`setTimeout`](https://nodejs.org/api/timers.html#timers_settimeout_callback_delay_args) function in javascript. `setTimeout` accepts a callback function that it will execute after a delay you specific.
+In javascript, whenever data is coming from a source not instantly available, either from an HTTP request via AJAX or a Database request. We're going to simulate having to wait for data using the [`setTimeout`](https://nodejs.org/api/timers.html#timers_settimeout_callback_delay_args) function in JavaScript. `setTimeout` accepts a callback function that it will execute after a delay you specify.
 
 **`setTimeout Example`**
 ```js
@@ -90,13 +90,13 @@ The goal is the same, to have `getData` return the JSON data, but this time, onl
 3. Returning data from internet after 1000 milliseconds.
 ```
 
-We can see that the execution order is no longer linear. Javascript did not wait for the call to `getData` to fully resolve before continuing to interpret the rest of the program. We wanted `data` to be our JSON object, but instead, we got some unidentified Javascript object. The script thought it ended before it actually did and finally, the `data` was returned, much too late, in fact, we never even really see it available in `main`.
+We can see that the execution order is no longer linear. JavaScript did not wait for the call to `getData` to fully resolve before continuing to interpret the rest of the program. We wanted `data` to be our JSON object, but instead, we got some unidentified JavaScript object. The script thought it ended before it actually did and finally, the `data` was returned, much too late, in fact, we never even really see it available in `main`.
 
-This is the asynchronous nature of javascript and to remedy it so that our scripts can wait for data to be returned we need to learn about `Promise`s.
+This is the asynchronous nature of JavaScript and to remedy it so that our scripts can wait for data to be returned we need to learn about `Promise`s.
 
-## A Javascript `Promise`
+## A JavaScript `Promise`
 
-In Javascript, we can wrap code that takes time to execute in something called a `Promise`. A `Promise` is almost exactly what it sounds like, a special object that promises to do something and resolve correctly, but just not right now. It helps us handle situations where we need to wait for something to occur and then provide a resolution.
+In JavaScript, we can wrap code that takes time to execute in something called a `Promise`. A `Promise` is almost exactly what it sounds like, a special object that promises to do something and resolve correctly, but just not right now. It helps us handle situations where we need to wait for something to occur and then provide a resolution.
 
 The basic syntax of a `Promise` is as follows:
 
@@ -104,13 +104,13 @@ The basic syntax of a `Promise` is as follows:
 new Promise(function(resolve) { resolve("Return Value") } );
 ```
 
-We instantiate an instance of `Promise`, passing the constructor our callback function of what the promise is promising to do. The argument that callback takes, `resolve`, is a special function that is called when the promise is done. Instead of using `return` in a promise to specify what the promise should return, we use `resolve`, saying this is the end of my promise, considered it fullfilled.
+We instantiate an instance of `Promise`, passing the constructor our callback function of what the promise is promising to do. The argument that callback takes, `resolve`, is a special function that is called when the promise is done. Instead of just using `return` in a promise to specify what the promise should return, we invoke the `resolve` function, saying this is the end of my promise, considered it fullfilled. You don't always have to explicitly state a return of the resolve function (i.e. `return resolve()` inside of the Promise unless you want the new Promise function to complete upon calling resolve. 
 
 We can attach code to execute upon the resolution of a promise using the `then` function on an unresolved promise. Here's an example.
 
 **File: [promiseExampleWithThen.js](https://github.com/learn-co-curriculum/node-promises-async-await-readme/blob/master/promiseExampleWithThen.js)**
 ```js
-let myFirstPromise = new Promise(function(resolve){
+const myFirstPromise = new Promise(function(resolve){
   // We call resolve(...) when what we were doing asynchronously was successful
   // In this example, we use setTimeout(...) to simulate async code. 
   setTimeout(function(){
@@ -173,21 +173,21 @@ Here's the simple promise example re-written with `async` and `await`:
 
 **File: [asyncAwaitPromiseExample.js](https://github.com/learn-co-curriculum/node-promises-async-await-readme/blob/master/asyncAwaitPromiseExample.js)**
 ```js
-let myFirstPromise = new Promise(function(resolve){
+const myFirstPromise = new Promise(function(resolve){
   setTimeout(function(){
     resolve("Success!");
   }, 1000);
 });
 
 async function main(){
-  let returnValueOfPromise = await myFirstPromise;
+  const returnValueOfPromise = await myFirstPromise;
   console.log("Yay! " + returnValueOfPromise);
 }
 
 main()
 ```
 
-First, any code that will use the `await` keyword must be wrapped within a function that is explicitly declared to be `async`. We accomplish this by declaring the `main` function with the syntax of `asnyc function main(){}`. The `async` keyword before a function declaration marks it as asynchronous and within it we can use the `await` keyword to wait for a promise to resolve.
+First, any code that will use the `await` keyword must be wrapped within a function that is explicitly declared to be `async`. We accomplish this by declaring the `main` function with the syntax of `asnyc function main(){}`. The `async` keyword before a function declaration marks it as asynchronous, and within it we can use the `await` keyword to wait for a promise to resolve.
 
 To wait for our promise to resolve and get the resolution as a return value from it, we just use the `await` keyword in-front of the promise.
 


### PR DESCRIPTION
@avi here is an update for the promises and async/await readme. Everything looks great. I added a note about explicitly returning the `resolve()` function (i.e. `return resolve()` ) in a promise, in the cases where you might not want code to run inside of the new Promise function after resolve is invoked. I think this is a great example, but is this the very first time async is taught? If so maybe a more simplified example of thinking about promises. I always use the example of:

I'm starting to cook dinner that will take a few hours, but I am missing a couple of ingredients. So I ask my roommate to go to the store and pick me up some rice and butter. My roommate says sure and heads out ("The roommate is making a promise of returning from the store"). Though I am waiting for my rice and butter there are still things I can be prepping and cooking for dinner that don't rely upon the rice and butter so I continue making dinner. Once my roommate arrives with the rice and butter (moving into the .then function callback) I then take the rice and butter and start making the risotto and complete my dinner.  

Might be something you can use somewhere in the lectures or a README. Students tend to grasp onto that concept for promises. If an additional lessons you go onto explain Promise rejections with the `.catch` function. I extend the story about how there was trouble for my roommate to make it to the store. Like a road closure, a storm, an accident, or the store simply didn't have the ingredients. It seems rejections are not part of this lab, and I think they are just additional fluff that would over bloat this specific README at the moment.